### PR TITLE
click on linestring to seek to point in video

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "@turf/bbox": "^6.0.0",
+    "@turf/nearest-point": "^5.1.5",
+    "@turf/nearest-point-on-line": "^6.0.1",
     "@turf/turf": "^5.1.6",
     "mapbox-gl": "^0.44.1"
   }


### PR DESCRIPTION
As a first step to being able to drag the marker, this allows the user to click on a point on the map, snaps to the closest point on the line-string, and starts playing video from that point.

I think we can merge this and work on actual "drag" functionality in a subsequent PR.

@geohacker could you look and merge?